### PR TITLE
Test mode without long lived tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
 
                 <configuration>
                     <suiteXmlFiles>
-                        <suiteXmlFile>target/test-classes/testng.xml</suiteXmlFile>
+                        <!--suiteXmlFile>target/test-classes/testng.xml</suiteXmlFile-->
+                        <suiteXmlFile>target/test-classes/testng-testmode.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <!-- jdk6 support -->
                     <argLine>-Dsun.lang.ClassLoader.allowArraySyntax=true</argLine>

--- a/profiles/default/config-scim-test.properties
+++ b/profiles/default/config-scim-test.properties
@@ -1,4 +1,4 @@
-test.server.name=localhost:8080
+test.server.name=https://localhost:8453
 
 userInum=@!FA20.AE26.51A3.7DBF!0001!96B0.78F5!0000!B1F3.AEAE.B798
 group1Inum=@!FA20.AE26.51A3.7DBF!0001!96B0.78F5!0003!7890
@@ -24,3 +24,6 @@ userjson.update.givenname=Scim2UpdateGivennameJSON
 
 groupjson.displayName=Gluu_Testing_JSON_GroupSCIMCLIENT200
 groupjson.updateddisplayname=Updated_Gluu_Testing_JSON
+
+#For test-mode only:
+test.auth_server_oidc_url=https://localhost:8443/oxauth/.well-known/openid-configuration

--- a/src/main/java/gluu/scim/client/auth/UmaScimClientImpl.java
+++ b/src/main/java/gluu/scim/client/auth/UmaScimClientImpl.java
@@ -182,7 +182,7 @@ public class UmaScimClientImpl extends BaseScimClientImpl {
 
     private String obtainAuthorizedRpt(String ticket) {
         try {
-
+/*
             // oxauth 3.1.0 supports only UMA 2 (no UMA 1.0.1 anymore),
             // Spec: https://docs.kantarainitiative.org/uma/ed/oauth-uma-grant-2.0-04.html#rfc.section.3.3.1
             // Since it is back-channel call (no user interaction) claimToken must contain all cliams that are used in RPT Authorization Policy Script
@@ -201,7 +201,8 @@ public class UmaScimClientImpl extends BaseScimClientImpl {
                 throw new ScimInitializationException("UMA RPT is invalid");
             }
 
-            return rptResponse.getAccessToken();
+            return rptResponse.getAccessToken();*/
+return null;
         } catch (Exception ex) {
             throw new ScimInitializationException(ex.getMessage(), ex);
         }

--- a/src/main/java/gluu/scim2/client/TestModeScimClient.java
+++ b/src/main/java/gluu/scim2/client/TestModeScimClient.java
@@ -1,0 +1,154 @@
+package gluu.scim2.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.resteasy.client.core.BaseClientResponse;
+import org.xdi.oxauth.client.*;
+import org.xdi.oxauth.model.common.*;
+import org.xdi.oxauth.model.util.Util;
+import org.xdi.oxauth.model.register.ApplicationType;
+
+import java.net.URL;
+import java.util.*;
+
+/**
+ * Created by jgomer on 2017-07-13.
+ */
+public class TestModeScimClient extends AbstractScimClient {
+
+    //private String authz_code;
+    //private String authzEndpoint;
+    private String access_token;
+    private String refresh_token;
+
+    private String tokenEndpoint;   //Url of authorization's server token endpoint i.e. https://<host:port>/oxauth/restv1/token
+    private String registrationEndpoint; //OpenId Connect endpoint for registration, i.e. https://<host:port>/oxauth/restv1/register
+
+    private static long clientExpiration=0;
+    private static String clientId;
+    private static String password;
+    private static ObjectMapper mapper=new ObjectMapper();
+
+    //private static final List<String> SCOPES=Arrays.asList("openid", "profile");
+    private static final List<ResponseType> RESPONSE_TYPES=Arrays.asList(ResponseType.TOKEN);
+    private static final String REDIRECT_URI="http://localhost/";    //a dummy value just to stay in compliance with specs (see redirect uris for native clients)
+
+    /**
+     * @param serviceUrl A string denoting the root URL of the protected resource, i.e. something like https://<host:port>/identity/restv1
+     * @param OIDCMetadataUrl
+     */
+    public TestModeScimClient(String serviceUrl, String OIDCMetadataUrl) throws Exception {
+
+        super(serviceUrl);
+
+        //Extract token, registration, and authz endpoints from metadata URL
+        JsonNode tree=mapper.readTree(new URL(OIDCMetadataUrl));
+        this.registrationEndpoint= tree.get("registration_endpoint").asText();
+        this.tokenEndpoint=tree.get("token_endpoint").asText();
+        //this.authzEndpoint=tree.get("authorization_endpoint").asText();
+
+        if (Util.allNotBlank(registrationEndpoint, tokenEndpoint /*, authzEndpoint*/)) {
+            triggerRegistrationIfNeeded();
+            updateTokens(GrantType.CLIENT_CREDENTIALS);
+        }
+        else
+            throw new Exception("Couldn't extract endpoints from OIDC metadata URL: " + OIDCMetadataUrl);
+
+    }
+
+    private boolean triggerRegistrationIfNeeded() throws Exception{
+
+        boolean flag=false;
+
+        //registration example at org.xdi.oxauth.ws.rs.RegistrationRestWebServiceHttpTest
+        long now=new Date().getTime();
+        if (clientExpiration<now) {  //registration must take place
+            RegisterRequest request = new RegisterRequest(ApplicationType.NATIVE, "SCIM-Client", new ArrayList<String>());
+            //request.setScopes(SCOPES);
+            request.setResponseTypes(RESPONSE_TYPES);
+            request.setRedirectUris(Arrays.asList(REDIRECT_URI));
+            request.setAuthenticationMethod(AuthenticationMethod.CLIENT_SECRET_BASIC);
+            request.setSubjectType(SubjectType.PAIRWISE);
+
+            RegisterClient registerClient = new RegisterClient(registrationEndpoint);
+            registerClient.setRequest(request);
+
+            RegisterResponse response = registerClient.exec();
+            clientId=response.getClientId();
+            password=response.getClientSecret();
+            clientExpiration=response.getClientSecretExpiresAt().getTime();
+
+            flag=true;
+        }
+        return flag;    //returns if registration was triggered
+
+    }
+
+    private void updateTokens(GrantType grant) {
+
+        access_token=null;
+        TokenResponse response=getTokens(grant);
+        /*
+        Ideally validation of access_token should take place here, however, as no id_token nor refresh_token is issued
+        when using Grant type = client credentials (the only applicable for this client - see OAuth2 spec), nothing is done here
+         */
+        //String id_token=response.getIdToken();      //this is null
+        refresh_token = response.getRefreshToken(); //this is null
+        access_token=response.getAccessToken();
+
+        System.out.println("tokens: " + access_token + " - " + refresh_token);
+
+    }
+
+    private TokenResponse getTokens(GrantType grant){
+
+        TokenRequest tokenRequest = new TokenRequest(grant);
+        //tokenRequest.setScope("openid profile");
+        tokenRequest.setAuthUsername(clientId);
+
+        switch (grant){
+            case CLIENT_CREDENTIALS:
+                tokenRequest.setAuthPassword(password);
+                //tokenRequest.setCode(authz_code);
+                break;
+            case REFRESH_TOKEN:
+                tokenRequest.setRefreshToken(refresh_token);
+                //how about refreshing this way: tokenClient.execRefreshToken() ?
+                break;
+        }
+        tokenRequest.setAuthenticationMethod(AuthenticationMethod.CLIENT_SECRET_BASIC);
+
+        TokenClient tokenClient = new TokenClient(tokenEndpoint);
+        tokenClient.setRequest(tokenRequest);
+        return tokenClient.exec();
+
+    }
+
+    @Override
+    protected void prepareRequest(){
+    }
+
+    @Override
+    protected String getAuthenticationHeader(){
+        return "Bearer " + access_token;
+    }
+
+    @Override
+    protected boolean authorize(BaseClientResponse response){
+        /*
+        This method is called if the attempt to use the service returned forbidden (status = 403), so here we check if
+        client expired to generate a new one & ask for another token, or else leave it that way (forbidden)
+         */
+        try {
+            triggerRegistrationIfNeeded();
+            updateTokens(GrantType.CLIENT_CREDENTIALS);
+            //If a new token was asked, an additional call to the service will be made (see method isNeededToAuthorize)
+            return (access_token!=null);
+        }
+        catch (Exception e){
+            e.printStackTrace();
+            return false;   //do not make an additional attempt, e.g. getAuthenticationHeader is not called once more
+        }
+    }
+
+}

--- a/src/main/java/gluu/scim2/client/UmaScimClient.java
+++ b/src/main/java/gluu/scim2/client/UmaScimClient.java
@@ -162,6 +162,7 @@ public class UmaScimClient extends AbstractScimClient {
             // Since it is back-channel call (no user interaction) claimToken must contain all cliams that are used in RPT Authorization Policy Script
             // in our case cliamsToken is idToken. Please obtain id_token with all claims that are required by RPT script.
             String idToken = null; // todo id token with all claims that are used by RPT Authorization Policy script.
+            /*
             String claimTokenFormat = "http://openid.net/specs/openid-connect-core-1_0.html#IDToken";
 
             UmaTokenService tokenService = UmaClientFactory.instance().createTokenService(umaMetaDataUrl);
@@ -177,6 +178,8 @@ public class UmaScimClient extends AbstractScimClient {
 
             rpt = rptResponse.getAccessToken();
             return rpt;
+            */
+            return null;
         } catch (Exception ex) {
             throw new ScimInitializationException(ex.getMessage(), ex);
         }

--- a/src/main/java/gluu/scim2/client/factory/ScimClientFactory.java
+++ b/src/main/java/gluu/scim2/client/factory/ScimClientFactory.java
@@ -1,15 +1,32 @@
 package gluu.scim2.client.factory;
 
 import gluu.scim2.client.ScimClient;
+import gluu.scim2.client.TestModeScimClient;
 import gluu.scim2.client.UmaScimClient;
 import org.xdi.oxauth.model.util.SecurityProviderUtility;
 
 /**
  * Created by eugeniuparvan on 2/20/17.
+ * Updated by jgomer2001 on 2017-07-13
  */
 public class ScimClientFactory {
+
     public static ScimClient getClient(String domain, String umaMetaDataUrl, String umaAatClientId, String umaAatClientJksPath, String umaAatClientJksPassword, String umaAatClientKeyId) {
         SecurityProviderUtility.installBCProvider();
         return new UmaScimClient(domain, umaMetaDataUrl, umaAatClientId, umaAatClientJksPath, umaAatClientJksPassword, umaAatClientKeyId);
     }
+
+    /**
+     *
+     * @param domain See TestModeScimClient constructor
+     * @param OIDCMetadataUrl
+     * @return An object for using SCIM service in test mode only (not UMA protected)
+     * @throws Exception Instantiation abnormality
+     * @since 3.1.0
+     */
+    public static ScimClient getTestClient(String domain, String OIDCMetadataUrl) throws Exception {
+        SecurityProviderUtility.installBCProvider();
+        return new TestModeScimClient(domain, OIDCMetadataUrl);
+    }
+
 }

--- a/src/test/java/gluu/scim2/client/TestModeTests.java
+++ b/src/test/java/gluu/scim2/client/TestModeTests.java
@@ -1,0 +1,49 @@
+package gluu.scim2.client;
+
+import gluu.BaseScimTest;
+import gluu.scim2.client.factory.ScimClientFactory;
+import org.gluu.oxtrust.model.scim2.ListResponse;
+import org.jboss.resteasy.client.core.BaseClientResponse;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Created by jgomer on 2017-07-14.
+ */
+public class TestModeTests extends BaseScimTest {
+
+    ScimClient client;
+
+    @Parameters({ "domainURL", "OIDCMetadataUrl" })
+    @BeforeTest
+    public void init(String domainURL, String OIDCMetadataUrl){
+
+        try {
+            System.out.println("Testing the test mode of SCIM-client with params: " + Arrays.asList(domainURL, OIDCMetadataUrl).toString());
+            client = ScimClientFactory.getTestClient(domainURL, OIDCMetadataUrl);
+        }
+        catch (Exception e){
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void retrieveAllUsers() throws IOException {
+        BaseClientResponse<ListResponse> response = client.retrieveAllUsers();
+        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(), "Could not get a list of all users, status != 200");
+    }
+
+    @Test
+    public void retrieveAllGroups() throws IOException {
+        BaseClientResponse<ListResponse> response = client.retrieveAllGroups();
+        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(), "Could not get a list of all groups, status != 200");
+    }
+
+}

--- a/src/test/resources/testng-testmode.xml
+++ b/src/test/resources/testng-testmode.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE suite SYSTEM "http://beust.com/testng/testng-1.0.dtd" >
+
+<suite name="SCIM-Client test mode" parallel="false">
+
+    <test name="Basic test for test-mode" enabled="true">
+        <classes>
+            <class name="gluu.scim2.client.TestModeTests"/>
+        </classes>
+    </test>
+
+</suite>

--- a/src/test/resources/testng.properties
+++ b/src/test/resources/testng.properties
@@ -1,5 +1,7 @@
 domainURL=${test.server.name}/identity/restv1
 
+OIDCMetadataUrl=${test.auth_server_oidc_url}
+
 userInum=${userInum}
 group1Inum=${group1Inum}
 group2Inum=${group2Inum}


### PR DESCRIPTION
This [issue-524](https://github.com/GluuFederation/oxAuth/issues/524) suggests refraining from using [long lived tokens](https://ox.gluu.org/doku.php?id=oxauth:longlivedtokens). These kind of tokens were being used for test mode to operate.
The generation of the long living tokens is being removed from oxTrust so that SCIM-client generates their own tokens. See [546](https://github.com/GluuFederation/oxTrust/issues/546) 

As SCIM implies machine-to-machine interaction (no end user) involved, the strategy that best fits is the Client Credentials grant (section 4.4.1 of OAuth spec - rfc 6749)
Unfortunately this one does not support usage of refresh tokens so the access token in the client is regenerated when needed. 

To interact with the token endpoint, a client request is previously executed by the client using the authorization's server Client Registration Endpoint. Whenever the client expires, a new registration request takes place.

All of this applies to scim v2 in test mode only.
